### PR TITLE
`BotAI.distribute_workers` convenience method

### DIFF
--- a/examples/distributed_workers.py
+++ b/examples/distributed_workers.py
@@ -25,8 +25,6 @@ class TerranBot(sc2.BotAI):
         if self.supply_left < 4 and not self.already_pending(UnitTypeId.SUPPLYDEPOT):
             if self.can_afford(UnitTypeId.SUPPLYDEPOT):
                 await self.build(UnitTypeId.SUPPLYDEPOT, near=cc.position.towards(self.game_info.map_center, 5))
-        for scv in self.units(UnitTypeId.SCV).idle:
-            await self.do(scv.gather(self.state.mineral_field.closest_to(cc)))
 
 
 run_game(maps.get("Abyssal Reef LE"), [

--- a/examples/distributed_workers.py
+++ b/examples/distributed_workers.py
@@ -1,0 +1,35 @@
+import sc2
+from sc2 import run_game, maps, Race, Difficulty
+from sc2.player import Bot, Computer
+from sc2.constants import *
+
+
+class TerranBot(sc2.BotAI):
+    async def on_step(self, state, iteration):
+        await self.distribute_workers()
+        await self.build_supply(state)
+        await self.build_workers(state)
+        await self.expand(state)
+
+    async def build_workers(self, state):
+        for cc in self.units(UnitTypeId.COMMANDCENTER).ready.noqueue:
+            if self.can_afford(UnitTypeId.SCV):
+                await self.do(cc.train(UnitTypeId.SCV))
+
+    async def expand(self, state):
+        if self.units(UnitTypeId.COMMANDCENTER).amount < 3 and self.can_afford(UnitTypeId.COMMANDCENTER):
+            await self.expand_now()
+
+    async def build_supply(self, state):
+        cc = self.units(UnitTypeId.COMMANDCENTER).ready.first
+        if self.supply_left < 4 and not self.already_pending(UnitTypeId.SUPPLYDEPOT):
+            if self.can_afford(UnitTypeId.SUPPLYDEPOT):
+                await self.build(UnitTypeId.SUPPLYDEPOT, near=cc.position.towards(self.game_info.map_center, 5))
+        for scv in self.units(UnitTypeId.SCV).idle:
+            await self.do(scv.gather(self.state.mineral_field.closest_to(cc)))
+
+
+run_game(maps.get("Abyssal Reef LE"), [
+    Bot(Race.Terran, TerranBot()),
+    Computer(Race.Protoss, Difficulty.Medium)
+], realtime=True)

--- a/examples/distributed_workers.py
+++ b/examples/distributed_workers.py
@@ -5,22 +5,22 @@ from sc2.constants import *
 
 
 class TerranBot(sc2.BotAI):
-    async def on_step(self, state, iteration):
+    async def on_step(self, iteration):
         await self.distribute_workers()
-        await self.build_supply(state)
-        await self.build_workers(state)
-        await self.expand(state)
+        await self.build_supply()
+        await self.build_workers()
+        await self.expand()
 
-    async def build_workers(self, state):
+    async def build_workers(self):
         for cc in self.units(UnitTypeId.COMMANDCENTER).ready.noqueue:
             if self.can_afford(UnitTypeId.SCV):
                 await self.do(cc.train(UnitTypeId.SCV))
 
-    async def expand(self, state):
+    async def expand(self):
         if self.units(UnitTypeId.COMMANDCENTER).amount < 3 and self.can_afford(UnitTypeId.COMMANDCENTER):
             await self.expand_now()
 
-    async def build_supply(self, state):
+    async def build_supply(self):
         cc = self.units(UnitTypeId.COMMANDCENTER).ready.first
         if self.supply_left < 4 and not self.already_pending(UnitTypeId.SUPPLYDEPOT):
             if self.can_afford(UnitTypeId.SUPPLYDEPOT):
@@ -30,4 +30,4 @@ class TerranBot(sc2.BotAI):
 run_game(maps.get("Abyssal Reef LE"), [
     Bot(Race.Terran, TerranBot()),
     Computer(Race.Protoss, Difficulty.Medium)
-], realtime=True)
+], realtime=False)

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -152,11 +152,9 @@ class BotAI(object):
             for x in range(0, deficit):
                 if worker_pool:
                     w = worker_pool.pop()
-                    mf = next(iter(filter(lambda r: r.type_id in [UnitTypeId.MINERALFIELD750, UnitTypeId.MINERALFIELD,
-                                                                  UnitTypeId.RICHMINERALFIELD750, UnitTypeId.RICHMINERALFIELD],
-                                          expansion_locations[location])))
+                    mf = self.state.mineral_field.closest_to(townhall)
                     if len(w.orders) == 1 and w.orders[0].ability.id in [AbilityId.HARVEST_RETURN]:
-                        await self.do(w.move(mf))
+                        await self.do(w.move(townhall))
                         await self.do(w.return_resource(queue=True))
                     else:
                         await self.do(w.gather(mf))

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -107,7 +107,7 @@ class BotAI(object):
 
     async def distribute_workers(self):
         expansion_locations = self.expansion_locations
-        owned_expansions = self.get_owned_expansions()
+        owned_expansions = self.owned_expansions
         worker_pool = []
         for location, townhall in owned_expansions.items():
             workers = self.workers.closer_than(20, location)
@@ -156,15 +156,16 @@ class BotAI(object):
                     else:
                         await self.do(w.gather(mf))
 
-    def get_owned_expansions(self):
-        owned_expansions = {}
+    @property
+    def owned_expansions(self):
+        owned = {}
         for el in self.expansion_locations:
             def is_near_to_expansion(t): return t.position.distance_to(el) < self.EXPANSION_GAP_THRESHOLD
             th = next((x for x in self.townhalls if is_near_to_expansion(x)), None)
             if th:
-                owned_expansions[el] = th
+                owned[el] = th
 
-        return owned_expansions
+        return owned
 
     def can_afford(self, item_id):
         if isinstance(item_id, UnitTypeId):

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -210,6 +210,7 @@ class BotAI(object):
         self.units = state.units.owned
         self.workers = self.units(race_worker[self.race])
         self.townhalls = self.units(race_townhalls[self.race])
+        self.geysers = self.units(race_gas[self.race])
 
         self.minerals = state.common.minerals
         self.vespene = state.common.vespene

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -109,6 +109,10 @@ class BotAI(object):
         expansion_locations = self.expansion_locations
         owned_expansions = self.owned_expansions
         worker_pool = []
+        for idle_worker in self.workers.idle:
+            mf = self.state.mineral_field.closest_to(idle_worker)
+            await self.do(idle_worker.gather(mf))
+
         for location, townhall in owned_expansions.items():
             workers = self.workers.closer_than(20, location)
             actual = townhall.assigned_harvesters

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -156,6 +156,7 @@ class BotAI(object):
                     if len(w.orders) == 1 and w.orders[0].ability.id in [AbilityId.HARVEST_RETURN]:
                         await self.do(w.move(townhall))
                         await self.do(w.return_resource(queue=True))
+                        await self.do(w.gather(mf, queue=True))
                     else:
                         await self.do(w.gather(mf))
 

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -148,7 +148,8 @@ class BotAI(object):
             for x in range(0, deficit):
                 if worker_pool:
                     w = worker_pool.pop()
-                    mf = next(iter(filter(lambda r: r.type_id in [UnitTypeId.MINERALFIELD750, UnitTypeId.MINERALFIELD],
+                    mf = next(iter(filter(lambda r: r.type_id in [UnitTypeId.MINERALFIELD750, UnitTypeId.MINERALFIELD,
+                                                                  UnitTypeId.RICHMINERALFIELD750, UnitTypeId.RICHMINERALFIELD],
                                           expansion_locations[location])))
                     if len(w.orders) == 1 and w.orders[0].ability.id in [AbilityId.HARVEST_RETURN]:
                         await self.do(w.move(mf))

--- a/sc2/data.py
+++ b/sc2/data.py
@@ -10,6 +10,7 @@ from .ids.unit_typeid import PROBE, SCV, DRONE
 from .ids.unit_typeid import NEXUS
 from .ids.unit_typeid import COMMANDCENTER, ORBITALCOMMAND, PLANETARYFORTRESS
 from .ids.unit_typeid import HATCHERY, LAIR, HIVE
+from .ids.unit_typeid import ASSIMILATOR, REFINERY, EXTRACTOR
 
 PlayerType = enum.Enum("PlayerType", sc_pb.PlayerType.items())
 Difficulty = enum.Enum("Difficulty", sc_pb.Difficulty.items())
@@ -39,4 +40,10 @@ race_townhalls = {
     Race.Protoss: {NEXUS},
     Race.Terran: {COMMANDCENTER, ORBITALCOMMAND, PLANETARYFORTRESS},
     Race.Zerg: {HATCHERY, LAIR, HIVE}
+}
+
+race_gas = {
+    Race.Protoss: ASSIMILATOR,
+    Race.Terran: REFINERY,
+    Race.Zerg: EXTRACTOR
 }

--- a/sc2/sc2process.py
+++ b/sc2/sc2process.py
@@ -78,7 +78,7 @@ class SC2Process(object):
                 "-dataDir", str(Paths.BASE),
                 "-tempDir", self._tmp_dir
             ],
-            cwd=str(Paths.CWD) if Paths.CWD else None,
+            cwd=(str(Paths.CWD) if Paths.CWD else None),
             #, env=run_config.env
         )
 

--- a/sc2/sc2process.py
+++ b/sc2/sc2process.py
@@ -78,7 +78,7 @@ class SC2Process(object):
                 "-dataDir", str(Paths.BASE),
                 "-tempDir", self._tmp_dir
             ],
-            cwd=str(Paths.CWD),
+            cwd=str(Paths.CWD) if Paths.CWD else None,
             #, env=run_config.env
         )
 

--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -190,6 +190,9 @@ class Unit(object):
     def gather(self, *args, **kwargs):
         return self(AbilityId.HARVEST_GATHER, *args, **kwargs)
 
+    def return_resource(self, *args, **kwargs):
+        return self(AbilityId.HARVEST_RETURN, *args, **kwargs)
+
     def move(self, *args, **kwargs):
         return self(AbilityId.MOVE, *args, **kwargs)
 


### PR DESCRIPTION
Convenience method to distribute workers based on "actual workers/ideal workers" indicator over townhalls and gas extractors. Gas is prioritized over minerals. This works by directly ordering random workers from an overpopulated expansion to gather in an expansion that needs more workers. In the case of overpopulated extractors, the action will be queued (i.e. they will move to the new expansion after getting some gas).

I've also included here the change of `expansion_locations` into a dictionary to add more utility to it. Luckily, iterators work on keys of a dictionary so nothing breaks - I think.

Fixes Issue #19 