### PR TITLE
Fixed typo in control_group.py

### DIFF
--- a/sc2/helpers/control_group.py
+++ b/sc2/helpers/control_group.py
@@ -15,14 +15,14 @@ class ControlGroup(set):
     def empty(self):
         return self.amount == 0
 
-    def add_unit(self, units):
+    def add_unit(self, unit):
         self.add(unit.tag)
 
     def add_units(self, units):
         for unit in units:
             self.add_unit(unit)
 
-    def remove_unit(self, units):
+    def remove_unit(self, unit):
         self.remove(unit.tag)
 
     def remove_units(self, units):


### PR DESCRIPTION
There was a typo in the add_unit and remove_unit methods