### PR TITLE
Fixed expansion positioning on threebase_voidray example.

### DIFF
--- a/examples/protoss/threebase_voidray.py
+++ b/examples/protoss/threebase_voidray.py
@@ -58,8 +58,7 @@ class ThreebaseVoidrayBot(sc2.BotAI):
 
         if self.units(NEXUS).amount < 3 and not self.already_pending(NEXUS):
             if self.can_afford(NEXUS):
-                location = await self.get_next_expansion()
-                await self.build(NEXUS, near=location)
+                await self.expand_now()
 
         if self.units(PYLON).ready.exists:
             pylon = self.units(PYLON).ready.random


### PR DESCRIPTION
Nexus was misplaced on some maps. I noticed this on Catalyst when the bot was placed lower right. Adding placement_step=1 also fixed the issue I think.