### PR TITLE
Load abilities faster

### DIFF
--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -69,10 +69,19 @@ class GameData(object):
         return Cost(0, 0)
 
 class AbilityData(object):
-    @staticmethod
-    def id_exists(ability_id: int) -> bool:
+    ability_ids: List[int] = []  # sorted list
+    for ability_id in AbilityId:  # 1000 items Enum is slow
+        ability_ids.append(ability_id.value)
+    ability_ids.remove(0)
+    ability_ids.sort()
+
+    @classmethod
+    def id_exists(cls, ability_id):
         assert isinstance(ability_id, int), f"Wrong type: {ability_id} is not int"
-        return ability_id != 0 and ability_id in (a.value for a in AbilityId)
+        if ability_id == 0:
+            return False
+        i = bisect_left(cls.ability_ids, ability_id)  # quick binary search
+        return i != len(cls.ability_ids) and cls.ability_ids[i] == ability_id
 
     def __init__(self, game_data, proto):
         self._game_data = game_data

--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -1,3 +1,4 @@
+from bisect import bisect_left
 from functools import lru_cache, reduce
 from typing import List, Dict, Set, Tuple, Any, Optional, Union # mypy type checking
 


### PR DESCRIPTION
Hi there!

I managed to reduce bot startup time from ~16 seconds down to ~5 seconds. The bottleneck was AbilityData.id_exists method, which used Enum lookup. AbilityId is a large enum, containing ~1000 items, and it was called for each of ~1000 abilities. Python enums are known to be rather slow.

So I've cached the ability ids in a sorted list and used binary search as a lookup strategy, effectively eliminating load times of GameData.abilities.