### PR TITLE
Find ramps faster

### DIFF
--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -69,10 +69,19 @@ class GameData(object):
         return Cost(0, 0)
 
 class AbilityData(object):
-    @staticmethod
-    def id_exists(ability_id: int) -> bool:
+    ability_ids: List[int] = []  # sorted list
+    for ability_id in AbilityId:  # 1000 items Enum is slow
+        ability_ids.append(ability_id.value)
+    ability_ids.remove(0)
+    ability_ids.sort()
+
+    @classmethod
+    def id_exists(cls, ability_id):
         assert isinstance(ability_id, int), f"Wrong type: {ability_id} is not int"
-        return ability_id != 0 and ability_id in (a.value for a in AbilityId)
+        if ability_id == 0:
+            return False
+        i = bisect_left(cls.ability_ids, ability_id)  # quick binary search
+        return i != len(cls.ability_ids) and cls.ability_ids[i] == ability_id
 
     def __init__(self, game_data, proto):
         self._game_data = game_data

--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -1,3 +1,4 @@
+from bisect import bisect_left
 from functools import lru_cache, reduce
 from typing import List, Dict, Set, Tuple, Any, Optional, Union # mypy type checking
 


### PR DESCRIPTION
I've managed to optimize ~4 seconds of time at bot startup (~16 seconds in debug mode).

Main offender was GameInfo._find_groups method which measured distance between each pair of points in a large collection. New implementation clusters the points by performing flood fill algorithm, essentially painting each ramp into a unique color. The boost is significant because only nearby points are compared.