### PR TITLE
Stop expand if no more places for expanding

### DIFF
--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -135,8 +135,9 @@ class BotAI(object):
 
         if not location:
             location = await self.get_next_expansion()
-
-        await self.build(building, near=location, max_distance=max_distance, random_alternative=False, placement_step=1)
+        
+        if location:
+            await self.build(building, near=location, max_distance=max_distance, random_alternative=False, placement_step=1)
 
     async def get_next_expansion(self) -> Optional[Point2]:
         """Find next expansion location."""
@@ -404,6 +405,8 @@ class BotAI(object):
             near = near.position.to2
         elif near is not None:
             near = near.to2
+        else:
+            return
 
         p = await self.find_placement(building, near.rounded, max_distance, random_alternative, placement_step)
         if p is None:


### PR DESCRIPTION
It complained "AttributeError: 'NoneType' object has no attribute 'rounded'" when my bot take every available places to build  main bases.  In that case, the location got from `get_next_expansion` will be None and cause the error.