### PR TITLE
Fix kill_switch signal handler

### DIFF
--- a/sc2/sc2process.py
+++ b/sc2/sc2process.py
@@ -52,7 +52,7 @@ class SC2Process:
     async def __aenter__(self):
         kill_switch.add(self)
 
-        def signal_handler():
+        def signal_handler(_signal, _frame):  # callback needs to accept two arguments, even if they are unused
             kill_switch.kill_all()
 
         signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
This fixes the signal handler for SIGINT.

The two arguments seem to have been removed in a previous commit, but they are actually necessary for the signal handler to match the expected signature. Without them, python throws a `TypeError`.