### PR TITLE
Fixes position.Point2.closest method

### DIFF
--- a/sc2/position.py
+++ b/sc2/position.py
@@ -52,6 +52,7 @@ class Pointlike(tuple):
         if len(ps) == 1:
             return ps[0]
         closest_distance_squared = math.inf
+        closest_element = ps[0]
         for p2 in ps:
             p2pos = p2
             if not isinstance(p2pos, Point2):


### PR DESCRIPTION
I found myself needing to get the closest element in a list of points set at `Point2(math.inf, math.inf)`. This was failing with the following exception

```
Traceback (most recent call last):
  File "/Users/jthomas/.pyenv/versions/3.6.5/lib/python3.6/site-packages/sc2/main.py", line 127, in _play_game_ai
    await ai.on_step(iteration)
  File "/Users/jthomas/git/lambdanaut-sc2/lambdanaut/bot.py", line 3112, in on_step
    await self.micro_manager.run()
  File "/Users/jthomas/git/lambdanaut-sc2/lambdanaut/bot.py", line 3021, in run
    await self.do_combat()
  File "/Users/jthomas/git/lambdanaut-sc2/lambdanaut/bot.py", line 2989, in do_combat
    nearest_enemy_cluster = army_center.closest(self.bot.enemy_clusters)
  File "/Users/jthomas/.pyenv/versions/3.6.5/lib/python3.6/site-packages/sc2/position.py", line 63, in closest
    return closest_element
UnboundLocalError: local variable 'closest_element' referenced before assignment
```

This sets the closest element to be the first one before continuing onwards to the next elements, and also fixes my problem. 