### PR TITLE
Use do_actions in WorkerRushBot

### DIFF
--- a/examples/worker_rush.py
+++ b/examples/worker_rush.py
@@ -1,12 +1,21 @@
-import sc2
-from sc2 import run_game, maps, Race, Difficulty
+from sc2 import run_game, maps, Race, Difficulty, BotAI
 from sc2.player import Bot, Computer
 
-class WorkerRushBot(sc2.BotAI):
+class WorkerRushBot(BotAI):
+    def __init__(self):
+        super().__init__()
+        self.actions = []
+
     async def on_step(self, iteration):
+        self.actions = []
+
         if iteration == 0:
+            target = self.enemy_start_locations[0]
+
             for worker in self.workers:
-                await self.do(worker.attack(self.enemy_start_locations[0]))
+                self.actions.append(worker.attack(target))
+
+        await self.do_actions(self.actions)
 
 def main():
     run_game(maps.get("Abyssal Reef LE"), [


### PR DESCRIPTION
WorkerRushBot is the closest thing to a template bot, and so it (and other examples) should use `do_actions()` instead of `do()`.

Similar changes exist in PR #177 as well, but it's stuck in review.