### PR TITLE
Workaround for incorrectly set lurker morph ability

### DIFF
--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -118,6 +118,12 @@ class AbilityData:
 
 class UnitTypeData:
     def __init__(self, game_data, proto):
+        # The ability_id for lurkers is
+        # LURKERASPECTMPFROMHYDRALISKBURROWED_LURKERMPFROMHYDRALISKBURROWED
+        # instead of the correct MORPH_LURKER.
+        if proto.unit_id == UnitTypeId.LURKERMP.value:
+            proto.ability_id = AbilityId.MORPH_LURKER.value
+
         self._game_data = game_data
         self._proto = proto
 


### PR DESCRIPTION
The client sets the lurker creation ability to `LURKERASPECTMPFROMHYDRALISKBURROWED_LURKERMPFROMHYDRALISKBURROWED` (which afaik is not a thing you can do). This patch sets it to the correct `MORPH_LURKER` when creating the `UnitTypeData` object.